### PR TITLE
Improve workflow queue accessibility and responsiveness

### DIFF
--- a/public/backend/css/custom.css
+++ b/public/backend/css/custom.css
@@ -1021,9 +1021,9 @@ input[type="radio"].methodInput:checked+label {
 }
 
 .queue-filters {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
   gap: var(--spacing-sm);
-  flex-wrap: wrap;
 }
 
 .filter-btn {
@@ -1038,6 +1038,13 @@ input[type="radio"].methodInput:checked+label {
   transition: all 0.2s ease;
   min-width: 60px;
   text-align: center;
+}
+
+.filter-btn__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 }
 
 .filter-btn:hover {
@@ -1073,6 +1080,16 @@ input[type="radio"].methodInput:checked+label {
   box-shadow: var(--shadow-sm);
   transition: all 0.2s ease;
   cursor: pointer;
+}
+
+.item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-sm);
 }
 
 .queue-item:hover {
@@ -1138,9 +1155,11 @@ input[type="radio"].methodInput:checked+label {
 
 .item-meta {
   display: flex;
+  align-items: center;
   gap: var(--spacing-md);
   font-size: var(--font-size-caption);
   color: var(--neutral-500);
+  flex-wrap: wrap;
 }
 
 .item-due {
@@ -1162,6 +1181,9 @@ input[type="radio"].methodInput:checked+label {
 }
 
 .btn-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: var(--spacing-xs) var(--spacing-sm);
   border: 1px solid var(--neutral-200);
   background: white;
@@ -1172,7 +1194,66 @@ input[type="radio"].methodInput:checked+label {
   cursor: pointer;
   transition: all 0.2s ease;
   min-width: 70px;
+}
+
+.btn-action__label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  gap: var(--spacing-xs);
+}
+
+.btn-action[aria-busy="true"] {
+  position: relative;
+  cursor: wait;
+}
+
+.btn-action[aria-busy="true"]::after {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  margin-left: var(--spacing-xs);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.queue-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xl) var(--spacing-lg);
   text-align: center;
+  color: var(--neutral-500);
+  border: 2px dashed var(--neutral-200);
+  border-radius: var(--border-radius-base);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.queue-empty-state__icon {
+  font-size: 2.5rem;
+}
+
+.queue-empty-state__title {
+  font-size: var(--font-size-h4);
+  font-weight: 600;
+  color: var(--neutral-800);
+  margin: 0;
+}
+
+.queue-empty-state__description {
+  margin: 0;
+  max-width: 360px;
 }
 
 .btn-action:hover {
@@ -1238,7 +1319,7 @@ input[type="radio"].methodInput:checked+label {
   }
 
   .queue-filters {
-    justify-content: center;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   }
 
   .queue-item {
@@ -1246,6 +1327,12 @@ input[type="radio"].methodInput:checked+label {
     align-items: stretch;
     gap: var(--spacing-sm);
     padding: var(--spacing-sm);
+  }
+
+  .item-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--spacing-xs);
   }
 
   .item-priority {
@@ -1283,8 +1370,7 @@ input[type="radio"].methodInput:checked+label {
 
 @media (max-width: 480px) {
   .queue-filters {
-    flex-direction: column;
-    align-items: stretch;
+    grid-template-columns: 1fr;
   }
 
   .filter-btn {
@@ -1383,6 +1469,20 @@ input[type="radio"].methodInput:checked+label {
   background: var(--neutral-700);
   border-color: var(--neutral-500);
   color: var(--neutral-100);
+}
+
+[data-theme="dark"] .queue-empty-state {
+  background: rgba(17, 24, 39, 0.7);
+  border-color: var(--neutral-700);
+  color: var(--neutral-300);
+}
+
+[data-theme="dark"] .queue-empty-state__title {
+  color: var(--neutral-100);
+}
+
+[data-theme="dark"] .queue-empty-state__description {
+  color: var(--neutral-400);
 }
 
 /* ========================================

--- a/resources/views/components/workflow-queue.blade.php
+++ b/resources/views/components/workflow-queue.blade.php
@@ -1,142 +1,178 @@
 @props(['queueItems' => []])
 
-<div class="workflow-queue" role="region" aria-label="Today's workflow queue" aria-live="polite">
+@php
+    $processingLabel = __('dashboard.processing');
+    if ($processingLabel === 'dashboard.processing') {
+        $processingLabel = 'Processing…';
+    }
+
+    $emptyStateTitle = __('dashboard.no_workflow_items_title');
+    if ($emptyStateTitle === 'dashboard.no_workflow_items_title') {
+        $emptyStateTitle = "You're all caught up";
+    }
+
+    $emptyStateDescription = __('dashboard.no_workflow_items_description');
+    if ($emptyStateDescription === 'dashboard.no_workflow_items_description') {
+        $emptyStateDescription = 'New tasks will appear here in real time.';
+    }
+
+    $filterEmptyTitle = __('dashboard.no_filtered_items_title');
+    if ($filterEmptyTitle === 'dashboard.no_filtered_items_title') {
+        $filterEmptyTitle = 'No tasks match this filter';
+    }
+
+    $filterEmptyDescription = __('dashboard.no_filtered_items_description');
+    if ($filterEmptyDescription === 'dashboard.no_filtered_items_description') {
+        $filterEmptyDescription = 'Try selecting a different priority or reset your filters.';
+    }
+
+    $todayWorkflowLabel = __('dashboard.today_workflow');
+    if ($todayWorkflowLabel === 'dashboard.today_workflow') {
+        $todayWorkflowLabel = "Today's Workflow";
+    }
+
+    $filterPriorityLabel = __('dashboard.filter_by_priority');
+    if ($filterPriorityLabel === 'dashboard.filter_by_priority') {
+        $filterPriorityLabel = 'Filter workflow items by priority';
+    }
+
+    $workflowItemsLabel = __('dashboard.workflow_queue_items');
+    if ($workflowItemsLabel === 'dashboard.workflow_queue_items') {
+        $workflowItemsLabel = 'Workflow queue items';
+    }
+
+    $dueLabel = __('dashboard.due');
+    if ($dueLabel === 'dashboard.due') {
+        $dueLabel = 'Due';
+    }
+
+    $filters = [
+        'all' => __('levels.all'),
+        'high' => __('levels.high'),
+        'medium' => __('levels.medium'),
+        'low' => __('levels.low'),
+    ];
+@endphp
+
+<div class="workflow-queue"
+     role="region"
+     aria-label="{{ $todayWorkflowLabel }}"
+     aria-live="polite"
+     data-processing-label="{{ $processingLabel }}">
   <div class="queue-header">
-    <h3 class="queue-title">{{ __('dashboard.today_workflow') ?? 'Today\'s Workflow' }}</h3>
-    <div class="queue-filters" role="group" aria-label="Filter workflow items by priority">
-      <button class="filter-btn active" data-priority="all" aria-pressed="true" tabindex="0">
-        {{ __('levels.all') ?? 'All' }}
-      </button>
-      <button class="filter-btn" data-priority="high" aria-pressed="false" tabindex="0">
-        {{ __('levels.high') ?? 'High' }}
-      </button>
-      <button class="filter-btn" data-priority="medium" aria-pressed="false" tabindex="0">
-        {{ __('levels.medium') ?? 'Medium' }}
-      </button>
-      <button class="filter-btn" data-priority="low" aria-pressed="false" tabindex="0">
-        {{ __('levels.low') ?? 'Low' }}
-      </button>
+    <h3 class="queue-title">{{ $todayWorkflowLabel }}</h3>
+    <div class="queue-filters" role="group" aria-label="{{ $filterPriorityLabel }}">
+      @foreach($filters as $priority => $label)
+        @php
+            $isActive = $loop->first;
+            $displayLabel = $label === "levels.$priority" ? ucfirst($priority) : $label;
+        @endphp
+        <button type="button"
+                class="filter-btn{{ $isActive ? ' active' : '' }}"
+                data-priority="{{ $priority }}"
+                aria-pressed="{{ $isActive ? 'true' : 'false' }}"
+                tabindex="0">
+          <span class="filter-btn__label">{{ $priority === 'all' ? ($label === 'levels.all' ? 'All' : $label) : $displayLabel }}</span>
+        </button>
+      @endforeach
     </div>
   </div>
 
-  <div class="queue-list" role="list" aria-label="Workflow queue items">
+  <div class="sr-only" aria-live="polite" aria-atomic="true" data-role="queue-status"></div>
+
+  <div class="queue-list" role="list" aria-label="{{ $workflowItemsLabel }}">
     @forelse($queueItems ?? [] as $item)
       <div class="queue-item priority-{{ $item['priority'] ?? 'medium' }}"
            role="listitem"
            data-priority="{{ $item['priority'] ?? 'medium' }}"
            data-type="{{ $item['type'] ?? 'pickup' }}"
            tabindex="0">
-        <div class="item-priority" aria-label="Priority: {{ ucfirst($item['priority'] ?? 'medium') }}">
-          {{ ucfirst($item['priority'] ?? 'medium') }}
+        <div class="item-header">
+          <div class="item-priority" aria-label="Priority: {{ ucfirst($item['priority'] ?? 'medium') }}">
+            {{ ucfirst($item['priority'] ?? 'medium') }}
+          </div>
+          <div class="item-meta">
+            <span class="item-due">{{ $dueLabel }}: {{ $item['due_time'] ?? 'N/A' }}</span>
+            <span class="item-type">{{ ucfirst($item['type'] ?? 'pickup') }}</span>
+          </div>
         </div>
         <div class="item-content">
           <h4 class="item-title">{{ $item['title'] ?? 'Task Title' }}</h4>
           <p class="item-details">{{ $item['details'] ?? 'Task details' }}</p>
-          <div class="item-meta">
-            <span class="item-due">{{ __('dashboard.due') ?? 'Due' }}: {{ $item['due_time'] ?? 'N/A' }}</span>
-            <span class="item-type">{{ ucfirst($item['type'] ?? 'pickup') }}</span>
-          </div>
         </div>
-        <div class="item-actions" role="group" aria-label="Quick actions for {{ $item['title'] ?? 'task' }}">
+        <div class="item-actions" role="group" aria-label="{{ __('dashboard.quick_actions_for') !== 'dashboard.quick_actions_for' ? __('dashboard.quick_actions_for', ['item' => $item['title'] ?? 'task']) : 'Quick actions for '.($item['title'] ?? 'task') }}">
           @if(hasPermission('assign_tasks') ?? true)
-            <button class="btn-action btn-assign"
+            @php
+                $assignLabel = __('dashboard.assign');
+                if ($assignLabel === 'dashboard.assign') {
+                    $assignLabel = 'Assign';
+                }
+            @endphp
+            <button type="button"
+                    class="btn-action btn-assign"
                     data-action="assign"
                     data-item-id="{{ $item['id'] ?? '' }}"
-                    aria-label="Assign {{ $item['title'] ?? 'task' }}"
+                    data-default-label="{{ $assignLabel }}"
+                    aria-label="{{ __('dashboard.assign_task') !== 'dashboard.assign_task' ? __('dashboard.assign_task', ['item' => $item['title'] ?? 'task']) : 'Assign '.($item['title'] ?? 'task') }}"
                     tabindex="0">
-              {{ __('dashboard.assign') ?? 'Assign' }}
+              <span class="btn-action__label">{{ $assignLabel }}</span>
             </button>
           @endif
           @if(hasPermission('reschedule_tasks') ?? true)
-            <button class="btn-action btn-reschedule"
+            @php
+                $rescheduleLabel = __('dashboard.reschedule');
+                if ($rescheduleLabel === 'dashboard.reschedule') {
+                    $rescheduleLabel = 'Reschedule';
+                }
+            @endphp
+            <button type="button"
+                    class="btn-action btn-reschedule"
                     data-action="reschedule"
                     data-item-id="{{ $item['id'] ?? '' }}"
-                    aria-label="Reschedule {{ $item['title'] ?? 'task' }}"
+                    data-default-label="{{ $rescheduleLabel }}"
+                    aria-label="{{ __('dashboard.reschedule_task') !== 'dashboard.reschedule_task' ? __('dashboard.reschedule_task', ['item' => $item['title'] ?? 'task']) : 'Reschedule '.($item['title'] ?? 'task') }}"
                     tabindex="0">
-              {{ __('dashboard.reschedule') ?? 'Reschedule' }}
+              <span class="btn-action__label">{{ $rescheduleLabel }}</span>
             </button>
           @endif
           @if(hasPermission('contact_customers') ?? true)
-            <button class="btn-action btn-contact"
+            @php
+                $contactLabel = __('dashboard.contact');
+                if ($contactLabel === 'dashboard.contact') {
+                    $contactLabel = 'Contact';
+                }
+            @endphp
+            <button type="button"
+                    class="btn-action btn-contact"
                     data-action="contact"
                     data-item-id="{{ $item['id'] ?? '' }}"
-                    aria-label="Contact customer for {{ $item['title'] ?? 'task' }}"
+                    data-default-label="{{ $contactLabel }}"
+                    aria-label="{{ __('dashboard.contact_customer') !== 'dashboard.contact_customer' ? __('dashboard.contact_customer', ['item' => $item['title'] ?? 'task']) : 'Contact customer for '.($item['title'] ?? 'task') }}"
                     tabindex="0">
-              {{ __('dashboard.contact') ?? 'Contact' }}
+              <span class="btn-action__label">{{ $contactLabel }}</span>
             </button>
           @endif
         </div>
       </div>
     @empty
-      <!-- Sample data for development -->
-      <div class="queue-item priority-high" role="listitem" data-priority="high" data-type="pickup" tabindex="0">
-        <div class="item-priority" aria-label="Priority: High">High</div>
-        <div class="item-content">
-          <h4 class="item-title">Pickup Request #12345</h4>
-          <p class="item-details">Customer: John Doe - Address: 123 Main St</p>
-          <div class="item-meta">
-            <span class="item-due">Due: 2 hours</span>
-            <span class="item-type">Pickup</span>
-          </div>
-        </div>
-        <div class="item-actions" role="group" aria-label="Quick actions for Pickup Request #12345">
-          <button class="btn-action btn-assign" data-action="assign" data-item-id="12345" aria-label="Assign Pickup Request #12345" tabindex="0">Assign</button>
-          <button class="btn-action btn-reschedule" data-action="reschedule" data-item-id="12345" aria-label="Reschedule Pickup Request #12345" tabindex="0">Reschedule</button>
-          <button class="btn-action btn-contact" data-action="contact" data-item-id="12345" aria-label="Contact customer for Pickup Request #12345" tabindex="0">Contact</button>
-        </div>
-      </div>
-
-      <div class="queue-item priority-medium" role="listitem" data-priority="medium" data-type="delivery" tabindex="0">
-        <div class="item-priority" aria-label="Priority: Medium">Medium</div>
-        <div class="item-content">
-          <h4 class="item-title">Delivery #67890</h4>
-          <p class="item-details">Customer: Jane Smith - Address: 456 Oak Ave</p>
-          <div class="item-meta">
-            <span class="item-due">Due: 4 hours</span>
-            <span class="item-type">Delivery</span>
-          </div>
-        </div>
-        <div class="item-actions" role="group" aria-label="Quick actions for Delivery #67890">
-          <button class="btn-action btn-assign" data-action="assign" data-item-id="67890" aria-label="Assign Delivery #67890" tabindex="0">Assign</button>
-          <button class="btn-action btn-reschedule" data-action="reschedule" data-item-id="67890" aria-label="Reschedule Delivery #67890" tabindex="0">Reschedule</button>
-          <button class="btn-action btn-contact" data-action="contact" data-item-id="67890" aria-label="Contact customer for Delivery #67890" tabindex="0">Contact</button>
-        </div>
-      </div>
-
-      <div class="queue-item priority-low" role="listitem" data-priority="low" data-type="exception" tabindex="0">
-        <div class="item-priority" aria-label="Priority: Low">Low</div>
-        <div class="item-content">
-          <h4 class="item-title">Exception Handling #11111</h4>
-          <p class="item-details">Issue: Damaged package - Customer: Bob Wilson</p>
-          <div class="item-meta">
-            <span class="item-due">Due: Tomorrow</span>
-            <span class="item-type">Exception</span>
-          </div>
-        </div>
-        <div class="item-actions" role="group" aria-label="Quick actions for Exception Handling #11111">
-          <button class="btn-action btn-assign" data-action="assign" data-item-id="11111" aria-label="Assign Exception Handling #11111" tabindex="0">Assign</button>
-          <button class="btn-action btn-reschedule" data-action="reschedule" data-item-id="11111" aria-label="Reschedule Exception Handling #11111" tabindex="0">Reschedule</button>
-          <button class="btn-action btn-contact" data-action="contact" data-item-id="11111" aria-label="Contact customer for Exception Handling #11111" tabindex="0">Contact</button>
-        </div>
-      </div>
-
-      <div class="queue-item priority-high" role="listitem" data-priority="high" data-type="customer-service" tabindex="0">
-        <div class="item-priority" aria-label="Priority: High">High</div>
-        <div class="item-content">
-          <h4 class="item-title">Customer Complaint #22222</h4>
-          <p class="item-details">Issue: Late delivery - Customer: Alice Brown</p>
-          <div class="item-meta">
-            <span class="item-due">Due: 1 hour</span>
-            <span class="item-type">Customer Service</span>
-          </div>
-        </div>
-        <div class="item-actions" role="group" aria-label="Quick actions for Customer Complaint #22222">
-          <button class="btn-action btn-assign" data-action="assign" data-item-id="22222" aria-label="Assign Customer Complaint #22222" tabindex="0">Assign</button>
-          <button class="btn-action btn-reschedule" data-action="reschedule" data-item-id="22222" aria-label="Reschedule Customer Complaint #22222" tabindex="0">Reschedule</button>
-          <button class="btn-action btn-contact" data-action="contact" data-item-id="22222" aria-label="Contact customer for Customer Complaint #22222" tabindex="0">Contact</button>
-        </div>
+      <div class="queue-empty-state" data-role="empty-state" role="status" aria-live="polite">
+        <div class="queue-empty-state__icon" aria-hidden="true">🗓️</div>
+        <h4 class="queue-empty-state__title">{{ $emptyStateTitle }}</h4>
+        <p class="queue-empty-state__description">{{ $emptyStateDescription }}</p>
       </div>
     @endforelse
+    @if(!empty($queueItems))
+      <div class="queue-empty-state queue-empty-state--filters"
+           data-role="filter-empty-state"
+           role="status"
+           aria-live="polite"
+           hidden
+           aria-hidden="true">
+        <div class="queue-empty-state__icon" aria-hidden="true">🗂️</div>
+        <h4 class="queue-empty-state__title" data-role="filter-empty-title">{{ $filterEmptyTitle }}</h4>
+        <p class="queue-empty-state__description" data-role="filter-empty-description">{{ $filterEmptyDescription }}</p>
+      </div>
+    @endif
   </div>
 </div>
 
@@ -149,6 +185,28 @@ document.addEventListener('DOMContentLoaded', function() {
   // Filter functionality
   const filterButtons = workflowQueue.querySelectorAll('.filter-btn');
   const queueItems = workflowQueue.querySelectorAll('.queue-item');
+  const statusRegion = workflowQueue.querySelector('[data-role="queue-status"]');
+  const processingLabel = workflowQueue.getAttribute('data-processing-label') || 'Processing…';
+  const filterEmptyState = workflowQueue.querySelector('[data-role="filter-empty-state"]');
+
+  const setButtonLabel = (button, label) => {
+    const labelElement = button.querySelector('.btn-action__label');
+    if (labelElement) {
+      labelElement.textContent = label;
+    } else {
+      button.textContent = label;
+    }
+  };
+
+  function announce(message) {
+    if (!message) return;
+
+    if (statusRegion) {
+      statusRegion.textContent = message;
+    } else {
+      announceToScreenReader(message);
+    }
+  }
 
   filterButtons.forEach(button => {
     button.addEventListener('click', function() {
@@ -173,9 +231,17 @@ document.addEventListener('DOMContentLoaded', function() {
         }
       });
 
+      let shouldShowFilterEmpty = false;
+      if (filterEmptyState) {
+        const hasVisibleItems = Array.from(queueItems).some(item => item.style.display !== 'none');
+        shouldShowFilterEmpty = !hasVisibleItems && queueItems.length > 0 && priority !== 'all';
+        filterEmptyState.hidden = !shouldShowFilterEmpty;
+        filterEmptyState.setAttribute('aria-hidden', shouldShowFilterEmpty ? 'false' : 'true');
+      }
+
       // Announce filter change to screen readers
-      const announcement = `Filtered to show ${priority === 'all' ? 'all' : priority + ' priority'} items`;
-      announceToScreenReader(announcement);
+      const announcement = `Filtered to show ${priority === 'all' ? 'all' : priority + ' priority'} items${shouldShowFilterEmpty ? '. No items match this filter' : ''}`;
+      announce(announcement);
     });
 
     // Keyboard navigation for filters
@@ -193,23 +259,32 @@ document.addEventListener('DOMContentLoaded', function() {
     button.addEventListener('click', function() {
       const action = this.getAttribute('data-action');
       const itemId = this.getAttribute('data-item-id');
-      const itemTitle = this.closest('.queue-item').querySelector('.item-title').textContent;
+      const queueItem = this.closest('.queue-item');
+      const itemTitleElement = queueItem ? queueItem.querySelector('.item-title') : null;
+      const itemTitle = itemTitleElement ? itemTitleElement.textContent.trim() : '';
+      const defaultLabel = this.getAttribute('data-default-label') || this.textContent.trim();
+      const actionLabel = defaultLabel || (action ? action.charAt(0).toUpperCase() + action.slice(1) : defaultLabel);
+      const busyLabel = this.getAttribute('data-processing-label') || processingLabel;
 
       // Placeholder for actual action handling
       console.log(`Action: ${action} for item ${itemId}: ${itemTitle}`);
 
       // Show loading state
       this.disabled = true;
-      this.textContent = 'Processing...';
+      this.setAttribute('aria-busy', 'true');
+      this.setAttribute('data-default-label', defaultLabel);
+      setButtonLabel(this, busyLabel);
+      announce(`${busyLabel} ${itemTitle}`.trim());
 
       // Simulate API call
       setTimeout(() => {
         this.disabled = false;
-        this.textContent = action.charAt(0).toUpperCase() + action.slice(1);
+        this.removeAttribute('aria-busy');
+        setButtonLabel(this, actionLabel);
 
         // Announce action completion
-        const announcement = `${action.charAt(0).toUpperCase() + action.slice(1)} action completed for ${itemTitle}`;
-        announceToScreenReader(announcement);
+        const announcement = `${actionLabel} action completed${itemTitle ? ` for ${itemTitle}` : ''}`;
+        announce(announcement);
       }, 1000);
     });
 
@@ -237,6 +312,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   // Screen reader announcement helper
   function announceToScreenReader(message) {
+    if (!message) return;
+
     const announcement = document.createElement('div');
     announcement.setAttribute('aria-live', 'polite');
     announcement.setAttribute('aria-atomic', 'true');
@@ -270,7 +347,7 @@ document.addEventListener('DOMContentLoaded', function() {
   function handleQueueUpdate(update) {
     // Placeholder for handling real-time updates
     console.log('Queue update received:', update);
-    announceToScreenReader('Workflow queue updated with new items');
+    announce('Workflow queue updated with new items');
   }
 
   // Initialize real-time updates


### PR DESCRIPTION
## Summary
- refresh the workflow queue component markup with localized fallbacks, live status messaging, and clearer empty states
- enhance client-side interactions for filter handling and action buttons, including aria-live updates and loading indicators
- expand custom styling to support the new structure, responsive filter layout, and accessible loading/empty-state visuals

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc2505b36c8324abcd84d2b500bd93