### PR TITLE
Rebuild home landing page with monochrome React components

### DIFF
--- a/react-dashboard/src/App.tsx
+++ b/react-dashboard/src/App.tsx
@@ -7,6 +7,7 @@ import Sidebar from './components/layout/Sidebar'
 import Header from './components/layout/Header'
 import Footer from './components/layout/Footer'
 import Dashboard from './pages/Dashboard'
+import Home from './pages/Home'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import { navigationConfig } from './config/navigation'
@@ -91,32 +92,11 @@ function AppContent() {
         {/* Page Content */}
         <main className="p-6">
           <Routes>
-            {/* Protected Dashboard Routes */}
-            <Route path="/" element={
-              <ProtectedRoute>
-                <Dashboard />
-              </ProtectedRoute>
-            } />
-            <Route path="/dashboard" element={
-              <ProtectedRoute>
-                <Dashboard />
-              </ProtectedRoute>
-            } />
-            <Route path="/analytics" element={
-              <ProtectedRoute>
-                <div className="p-6"><h1 className="text-2xl font-bold">Analytics</h1></div>
-              </ProtectedRoute>
-            } />
-            <Route path="/reports" element={
-              <ProtectedRoute>
-                <div className="p-6"><h1 className="text-2xl font-bold">Reports</h1></div>
-              </ProtectedRoute>
-            } />
-            <Route path="/settings" element={
-              <ProtectedRoute>
-                <div className="p-6"><h1 className="text-2xl font-bold">Settings</h1></div>
-              </ProtectedRoute>
-            } />
+            <Route index element={<Dashboard />} />
+            <Route path="dashboard" element={<Dashboard />} />
+            <Route path="analytics" element={<div className="p-6"><h1 className="text-2xl font-bold">Analytics</h1></div>} />
+            <Route path="reports" element={<div className="p-6"><h1 className="text-2xl font-bold">Reports</h1></div>} />
+            <Route path="settings" element={<div className="p-6"><h1 className="text-2xl font-bold">Settings</h1></div>} />
           </Routes>
         </main>
       </div>
@@ -133,11 +113,19 @@ function App() {
         <Router>
           <Routes>
             {/* Public Routes */}
+            <Route path="/" element={<Home />} />
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
 
-            {/* Protected Routes */}
-            <Route path="/*" element={<AppContent />} />
+            {/* Protected Dashboard */}
+            <Route
+              path="/dashboard/*"
+              element={(
+                <ProtectedRoute>
+                  <AppContent />
+                </ProtectedRoute>
+              )}
+            />
           </Routes>
         </Router>
       </AuthProvider>

--- a/react-dashboard/src/components/home/AchievementsSection.tsx
+++ b/react-dashboard/src/components/home/AchievementsSection.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import type { AchievementItem } from '../../types/home';
+import './home.css';
+
+interface AchievementsSectionProps {
+  items: AchievementItem[];
+}
+
+const formatNumber = (value: number) => {
+  if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(1).replace(/\.0$/, '')}M`;
+  }
+
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1).replace(/\.0$/, '')}K`;
+  }
+
+  return value.toString();
+};
+
+const AnimatedValue = ({ value, suffix }: { value: number; suffix?: string }) => {
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useEffect(() => {
+    let frame = 0;
+    const totalFrames = 24;
+    const increment = value / totalFrames;
+
+    const tick = () => {
+      frame += 1;
+      if (frame >= totalFrames) {
+        setDisplayValue(value);
+        return;
+      }
+      setDisplayValue((prev) => Math.min(value, prev + increment));
+      requestAnimationFrame(tick);
+    };
+
+    tick();
+  }, [value]);
+
+  return (
+    <span>
+      {formatNumber(Math.round(displayValue))}
+      {suffix ?? ''}
+    </span>
+  );
+};
+
+const AchievementsSection = ({ items }: AchievementsSectionProps) => {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section achievements-section">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Happy Achievements</h2>
+          <p className="section-lead">Milestones that reflect our dedication to better deliveries.</p>
+        </header>
+        <div className="grid achievements-grid">
+          {items.map((item) => (
+            <article key={item.id} className="achievement-card">
+              <div className="achievement-icon" aria-hidden="true">
+                <i className={item.icon} />
+              </div>
+              <p className="achievement-value" aria-live="polite">
+                <AnimatedValue value={item.value} suffix={item.suffix} />
+              </p>
+              <p className="achievement-label">{item.label}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AchievementsSection;

--- a/react-dashboard/src/components/home/BannerSection.tsx
+++ b/react-dashboard/src/components/home/BannerSection.tsx
@@ -1,0 +1,72 @@
+import { FormEvent, useState } from 'react';
+import type { BannerContent } from '../../types/home';
+import './home.css';
+
+interface BannerSectionProps {
+  content: BannerContent;
+  onTrack?: (trackingId: string) => void;
+}
+
+const BannerSection = ({ content, onTrack }: BannerSectionProps) => {
+  const [trackingId, setTrackingId] = useState('');
+  const [submittedId, setSubmittedId] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!trackingId.trim()) {
+      return;
+    }
+
+    setSubmittedId(trackingId.trim());
+    onTrack?.(trackingId.trim());
+    setTrackingId('');
+  };
+
+  return (
+    <section className="home-section home-banner">
+      <div className="home-container banner-grid">
+        <div className="banner-copy">
+          <div className="banner-title" aria-live="polite">
+            {content.titleSegments.map((segment, index) => (
+              <span
+                key={`${segment.text}-${index}`}
+                className={segment.highlight ? 'banner-title-highlight' : undefined}
+              >
+                {segment.text}
+              </span>
+            ))}
+          </div>
+          <p className="banner-subtitle">{content.subtitle}</p>
+          <form className="tracking-form" onSubmit={handleSubmit}>
+            <label htmlFor="tracking-id" className="sr-only">
+              {content.trackingPlaceholder}
+            </label>
+            <input
+              id="tracking-id"
+              type="text"
+              value={trackingId}
+              onChange={(event) => setTrackingId(event.target.value)}
+              placeholder={content.trackingPlaceholder}
+              className="tracking-input"
+            />
+            <button type="submit" className="tracking-button">
+              {content.trackingButtonLabel}
+            </button>
+          </form>
+          {submittedId && (
+            <p className="tracking-feedback" role="status">
+              Tracking lookup started for <span>{submittedId}</span>
+            </p>
+          )}
+        </div>
+        {content.imageUrl && (
+          <div className="banner-visual" aria-hidden="true">
+            <img src={content.imageUrl} alt="" className="banner-image" />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default BannerSection;

--- a/react-dashboard/src/components/home/BlogsSection.tsx
+++ b/react-dashboard/src/components/home/BlogsSection.tsx
@@ -1,0 +1,53 @@
+import type { BlogItem } from '../../types/home';
+import './home.css';
+
+interface BlogsSectionProps {
+  items: BlogItem[];
+}
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+};
+
+const BlogsSection = ({ items }: BlogsSectionProps) => {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Blogs</h2>
+          <p className="section-lead">Insights for logistics teams shaping the future of delivery.</p>
+        </header>
+        <div className="grid blogs-grid">
+          {items.map((item) => (
+            <article key={item.id} className="blog-card">
+              <a href={item.link} className="blog-visual" aria-label={item.title}>
+                <img src={item.imageUrl} alt="" className="blog-image" />
+              </a>
+              <div className="blog-body">
+                <a href={item.link} className="card-title-link">
+                  <h3 className="card-title">{item.title}</h3>
+                </a>
+                <div className="blog-meta">
+                  <span>{item.author}</span>
+                  <span>{item.views.toLocaleString()} views</span>
+                  <time dateTime={item.updatedAt}>{formatDate(item.updatedAt)}</time>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BlogsSection;

--- a/react-dashboard/src/components/home/PartnersSection.tsx
+++ b/react-dashboard/src/components/home/PartnersSection.tsx
@@ -1,0 +1,37 @@
+import type { PartnerItem } from '../../types/home';
+import './home.css';
+
+interface PartnersSectionProps {
+  partners: PartnerItem[];
+}
+
+const PartnersSection = ({ partners }: PartnersSectionProps) => {
+  if (!partners.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Our Partners</h2>
+          <p className="section-lead">Trusted brands that rely on our delivery network.</p>
+        </header>
+        <div className="partner-track" role="list">
+          {partners.map((partner) => (
+            <a
+              key={partner.id}
+              href={partner.link}
+              className="partner-card"
+              role="listitem"
+            >
+              <img src={partner.imageUrl} alt={partner.name} className="partner-image" />
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PartnersSection;

--- a/react-dashboard/src/components/home/PricingSection.tsx
+++ b/react-dashboard/src/components/home/PricingSection.tsx
@@ -1,0 +1,74 @@
+import { useMemo, useState } from 'react';
+import type { PricingTier } from '../../types/home';
+import './home.css';
+
+interface PricingSectionProps {
+  tiers: PricingTier[];
+  currency?: string;
+}
+
+const PricingSection = ({ tiers, currency = '$' }: PricingSectionProps) => {
+  const [activeTierId, setActiveTierId] = useState<PricingTier['id']>(tiers[0]?.id ?? 'same_day');
+
+  const activeTier = useMemo(
+    () => tiers.find((tier) => tier.id === activeTierId) ?? tiers[0],
+    [tiers, activeTierId]
+  );
+
+  if (!tiers.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section" id="pricing">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Pricing</h2>
+          <p className="section-lead">Transparent rates that make planning effortless.</p>
+        </header>
+
+        <div className="pricing-tabs" role="tablist" aria-label="Delivery pricing tiers">
+          {tiers.map((tier) => (
+            <button
+              key={tier.id}
+              type="button"
+              role="tab"
+              aria-selected={tier.id === activeTierId}
+              aria-controls={`pricing-panel-${tier.id}`}
+              id={`pricing-tab-${tier.id}`}
+              className={`pricing-tab ${tier.id === activeTierId ? 'pricing-tab-active' : ''}`}
+              onClick={() => setActiveTierId(tier.id)}
+            >
+              {tier.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTier && (
+          <div
+            id={`pricing-panel-${activeTier.id}`}
+            role="tabpanel"
+            aria-labelledby={`pricing-tab-${activeTier.id}`}
+            className="pricing-panel"
+          >
+            <div className="grid pricing-grid">
+              {activeTier.rates.map((rate) => (
+                <article key={rate.id} className="pricing-card">
+                  <p className="pricing-weight">{rate.weight}</p>
+                  <h3 className="pricing-price">
+                    <span className="sr-only">Price: </span>
+                    {currency}
+                    {rate.price.toFixed(2)}
+                  </h3>
+                  <p className="pricing-category">{rate.category}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PricingSection;

--- a/react-dashboard/src/components/home/ServicesSection.tsx
+++ b/react-dashboard/src/components/home/ServicesSection.tsx
@@ -1,0 +1,43 @@
+import type { ServiceItem } from '../../types/home';
+import './home.css';
+
+interface ServicesSectionProps {
+  services: ServiceItem[];
+}
+
+const ServicesSection = ({ services }: ServicesSectionProps) => {
+  if (!services.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Our Services</h2>
+          <p className="section-lead">
+            Focused, reliable delivery options designed for every business rhythm.
+          </p>
+        </header>
+        <div className="grid services-grid">
+          {services.map((service) => (
+            <article key={service.id} className="service-card">
+              <div className="service-visual" aria-hidden="true">
+                <img src={service.imageUrl} alt="" className="service-image" />
+              </div>
+              <div className="service-copy">
+                <h3 className="card-title">{service.title}</h3>
+                <p className="card-text">{service.description}</p>
+                <a className="text-link" href={service.link}>
+                  Explore
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ServicesSection;

--- a/react-dashboard/src/components/home/WhyCourierSection.tsx
+++ b/react-dashboard/src/components/home/WhyCourierSection.tsx
@@ -1,0 +1,36 @@
+import type { WhyCourierItem } from '../../types/home';
+import './home.css';
+
+interface WhyCourierSectionProps {
+  items: WhyCourierItem[];
+  companyName?: string;
+}
+
+const WhyCourierSection = ({ items, companyName = 'Our Courier' }: WhyCourierSectionProps) => {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <section className="home-section">
+      <div className="home-container">
+        <header className="section-header">
+          <h2 className="section-title">Why {companyName}</h2>
+          <p className="section-lead">The essential promises that keep our deliveries personal and precise.</p>
+        </header>
+        <div className="grid why-grid">
+          {items.map((item) => (
+            <article key={item.id} className="why-card">
+              <div className="why-visual" aria-hidden="true">
+                <img src={item.imageUrl} alt="" className="why-image" />
+              </div>
+              <h3 className="card-title text-center">{item.title}</h3>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WhyCourierSection;

--- a/react-dashboard/src/components/home/home.css
+++ b/react-dashboard/src/components/home/home.css
@@ -1,0 +1,454 @@
+.home-page {
+  background-color: var(--color-mono-white);
+  color: var(--color-mono-gray-900);
+}
+
+.home-section {
+  padding: 4rem 0;
+  background-color: var(--color-mono-white);
+  color: var(--color-mono-gray-900);
+}
+
+.home-section:nth-of-type(even) {
+  background-color: var(--color-mono-gray-50);
+}
+
+.home-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-title {
+  font-size: 2.25rem;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  text-transform: uppercase;
+  color: var(--color-mono-black);
+  margin-bottom: 0.5rem;
+}
+
+.section-lead {
+  font-size: 1rem;
+  color: var(--color-mono-gray-600);
+  max-width: 38rem;
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.banner-grid {
+  display: grid;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.banner-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.banner-title {
+  display: grid;
+  gap: 0.5rem;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  text-transform: uppercase;
+  line-height: 1.05;
+  font-weight: 700;
+}
+
+.banner-title span {
+  display: inline-block;
+}
+
+.banner-title-highlight {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--color-mono-black);
+  border-radius: 9999px;
+  background-color: var(--color-mono-white);
+}
+
+.banner-subtitle {
+  font-size: 1.1rem;
+  color: var(--color-mono-gray-600);
+  max-width: 30rem;
+}
+
+.tracking-form {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.tracking-input {
+  flex: 1;
+  min-width: 14rem;
+  padding: 0.85rem 1.1rem;
+  border: 1px solid var(--color-mono-gray-300);
+  border-radius: 9999px;
+  background-color: var(--color-mono-white);
+  color: var(--color-mono-gray-900);
+  font-size: 1rem;
+}
+
+.tracking-input:focus {
+  outline: none;
+  border-color: var(--color-mono-black);
+}
+
+.tracking-button {
+  padding: 0.85rem 1.8rem;
+  border-radius: 9999px;
+  border: 1px solid var(--color-mono-black);
+  background-color: var(--color-mono-black);
+  color: var(--color-mono-white);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.tracking-button:hover {
+  background-color: var(--color-mono-gray-900);
+}
+
+.tracking-feedback {
+  font-size: 0.95rem;
+  color: var(--color-mono-gray-600);
+}
+
+.tracking-feedback span {
+  font-weight: 600;
+  color: var(--color-mono-black);
+}
+
+.banner-visual {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.banner-image {
+  max-width: 100%;
+  width: min(520px, 100%);
+  border-radius: 24px;
+  border: 1px solid var(--color-mono-gray-200);
+  background: var(--color-mono-white);
+  filter: grayscale(100%);
+}
+
+.services-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.service-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 24px;
+  border: 1px solid var(--color-mono-gray-200);
+  background-color: var(--color-mono-white);
+  box-shadow: var(--shadow-subtle);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.service-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-normal);
+}
+
+.service-visual {
+  width: 100%;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px dashed var(--color-mono-gray-300);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-mono-gray-50);
+}
+
+.service-image {
+  max-width: 160px;
+  filter: grayscale(100%);
+}
+
+.service-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--color-mono-black);
+  margin: 0;
+}
+
+.card-text {
+  color: var(--color-mono-gray-600);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.card-title-link {
+  text-decoration: none;
+}
+
+.card-title-link:hover .card-title {
+  text-decoration: underline;
+}
+
+.text-link {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-mono-black);
+}
+
+.why-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.why-card {
+  padding: 2rem;
+  border-radius: 24px;
+  border: 1px solid var(--color-mono-gray-200);
+  background: var(--color-mono-white);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.why-visual {
+  width: 100%;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px dashed var(--color-mono-gray-300);
+  background: var(--color-mono-gray-50);
+}
+
+.why-image {
+  width: min(160px, 100%);
+  filter: grayscale(100%);
+}
+
+.pricing-tabs {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.pricing-tab {
+  padding: 0.65rem 1.4rem;
+  border-radius: 9999px;
+  border: 1px solid var(--color-mono-gray-300);
+  background: transparent;
+  color: var(--color-mono-gray-600);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pricing-tab-active {
+  color: var(--color-mono-white);
+  background-color: var(--color-mono-black);
+  border-color: var(--color-mono-black);
+}
+
+.pricing-panel {
+  border-radius: 32px;
+  border: 1px solid var(--color-mono-gray-200);
+  padding: 2.5rem;
+  background: var(--color-mono-white);
+  box-shadow: var(--shadow-subtle);
+}
+
+.pricing-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.pricing-card {
+  padding: 1.5rem;
+  border-radius: 20px;
+  border: 1px solid var(--color-mono-gray-200);
+  background: var(--color-mono-gray-50);
+  text-align: center;
+}
+
+.pricing-weight {
+  font-size: 0.9rem;
+  color: var(--color-mono-gray-600);
+  margin-bottom: 0.75rem;
+}
+
+.pricing-price {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: var(--color-mono-black);
+  margin-bottom: 0.5rem;
+}
+
+.pricing-category {
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-mono-gray-500);
+}
+
+.achievements-section {
+  background: var(--color-mono-black);
+  color: var(--color-mono-white);
+}
+
+.achievements-section .section-title,
+.achievements-section .section-lead {
+  color: var(--color-mono-white);
+}
+
+.achievements-grid {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.achievement-card {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 1.5rem;
+}
+
+.achievement-icon {
+  font-size: 2rem;
+}
+
+.achievement-value {
+  font-size: 2.5rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.achievement-label {
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-mono-gray-300);
+}
+
+.partner-track {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.partner-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  border-radius: 18px;
+  border: 1px solid var(--color-mono-gray-200);
+  background: var(--color-mono-white);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.partner-card:hover {
+  box-shadow: var(--shadow-normal);
+  transform: translateY(-4px);
+}
+
+.partner-image {
+  max-width: 140px;
+  filter: grayscale(100%);
+}
+
+.blogs-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.blog-card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid var(--color-mono-gray-200);
+  background: var(--color-mono-white);
+  box-shadow: var(--shadow-subtle);
+}
+
+.blog-visual {
+  display: block;
+}
+
+.blog-image {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  filter: grayscale(100%);
+}
+
+.blog-body {
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.blog-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--color-mono-gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+@media (min-width: 768px) {
+  .banner-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .banner-title {
+    font-size: clamp(2rem, 8vw, 3rem);
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+  }
+
+  .pricing-panel {
+    padding: 1.75rem;
+  }
+}
+
+.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/react-dashboard/src/data/mockHomeData.ts
+++ b/react-dashboard/src/data/mockHomeData.ts
@@ -1,0 +1,191 @@
+import type { HomePageContent } from '../types/home';
+
+const placeholderImage =
+  'data:image/svg+xml;utf8,' +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="480" height="320" viewBox="0 0 480 320">` +
+      `<rect width="480" height="320" fill="#f5f5f5"/>` +
+      `<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="#999999" font-family="Helvetica, Arial, sans-serif" font-size="24">Placeholder</text>` +
+    `</svg>`
+  );
+
+export const mockHomeData: HomePageContent = {
+  banner: {
+    titleSegments: [
+      { text: 'Logistics' },
+      { text: 'Delivered Right', highlight: true },
+      { text: 'On Time' },
+    ],
+    subtitle: 'Track parcels, manage deliveries, and delight customers with a frictionless courier experience.',
+    imageUrl: placeholderImage,
+    trackingPlaceholder: 'Enter tracking ID',
+    trackingButtonLabel: 'Track Now',
+  },
+  services: [
+    {
+      id: 'express',
+      title: 'Express Delivery',
+      description: 'Same-day pickup and delivery service tailored for urgent parcels with guaranteed time slots.',
+      imageUrl: placeholderImage,
+      link: '/services/express',
+    },
+    {
+      id: 'next-day',
+      title: 'Next Day Delivery',
+      description: 'Cost-effective delivery that keeps reliability high with early morning distribution runs.',
+      imageUrl: placeholderImage,
+      link: '/services/next-day',
+    },
+    {
+      id: 'sub-city',
+      title: 'Sub City',
+      description: 'Optimized micro-fulfillment hubs keep suburban deliveries efficient and predictable.',
+      imageUrl: placeholderImage,
+      link: '/services/sub-city',
+    },
+    {
+      id: 'outside-city',
+      title: 'Outside City',
+      description: 'Cross-city deliveries with dedicated linehaul support and transparent milestone tracking.',
+      imageUrl: placeholderImage,
+      link: '/services/outside-city',
+    },
+  ],
+  whyCourier: [
+    {
+      id: 'coverage',
+      title: 'Nationwide Coverage',
+      imageUrl: placeholderImage,
+    },
+    {
+      id: 'visibility',
+      title: 'Real-time Visibility',
+      imageUrl: placeholderImage,
+    },
+    {
+      id: 'support',
+      title: 'Dedicated Support',
+      imageUrl: placeholderImage,
+    },
+  ],
+  pricing: [
+    {
+      id: 'same_day',
+      label: 'Same Day',
+      rates: [
+        { id: 'sd-1', weight: 'Up to 1kg', category: 'Documents', price: 6.5 },
+        { id: 'sd-2', weight: 'Up to 3kg', category: 'Parcel', price: 8.75 },
+        { id: 'sd-3', weight: 'Up to 5kg', category: 'Parcel', price: 11.0 },
+      ],
+    },
+    {
+      id: 'next_day',
+      label: 'Next Day',
+      rates: [
+        { id: 'nd-1', weight: 'Up to 1kg', category: 'Documents', price: 4.5 },
+        { id: 'nd-2', weight: 'Up to 3kg', category: 'Parcel', price: 6.25 },
+        { id: 'nd-3', weight: 'Up to 5kg', category: 'Parcel', price: 7.75 },
+      ],
+    },
+    {
+      id: 'sub_city',
+      label: 'Sub City',
+      rates: [
+        { id: 'sc-1', weight: 'Up to 1kg', category: 'Documents', price: 5.25 },
+        { id: 'sc-2', weight: 'Up to 3kg', category: 'Parcel', price: 7.25 },
+        { id: 'sc-3', weight: 'Up to 5kg', category: 'Parcel', price: 9.0 },
+      ],
+    },
+    {
+      id: 'outside_city',
+      label: 'Outside City',
+      rates: [
+        { id: 'oc-1', weight: 'Up to 1kg', category: 'Documents', price: 9.0 },
+        { id: 'oc-2', weight: 'Up to 3kg', category: 'Parcel', price: 12.5 },
+        { id: 'oc-3', weight: 'Up to 5kg', category: 'Parcel', price: 16.0 },
+      ],
+    },
+  ],
+  achievements: [
+    {
+      id: 'branches',
+      icon: 'fas fa-map-marker-alt',
+      label: 'Active Branches',
+      value: 48,
+    },
+    {
+      id: 'parcels',
+      icon: 'fas fa-box',
+      label: 'Parcels Delivered',
+      value: 125000,
+    },
+    {
+      id: 'merchants',
+      icon: 'fas fa-store',
+      label: 'Merchants Onboarded',
+      value: 980,
+    },
+    {
+      id: 'reviews',
+      icon: 'fas fa-star',
+      label: 'Five-star Reviews',
+      value: 4200,
+      suffix: '+',
+    },
+  ],
+  partners: [
+    {
+      id: 'partner-1',
+      name: 'Northwind',
+      imageUrl: placeholderImage,
+      link: 'https://example.com/partners/northwind',
+    },
+    {
+      id: 'partner-2',
+      name: 'Contoso',
+      imageUrl: placeholderImage,
+      link: 'https://example.com/partners/contoso',
+    },
+    {
+      id: 'partner-3',
+      name: 'Globex',
+      imageUrl: placeholderImage,
+      link: 'https://example.com/partners/globex',
+    },
+    {
+      id: 'partner-4',
+      name: 'Initech',
+      imageUrl: placeholderImage,
+      link: 'https://example.com/partners/initech',
+    },
+  ],
+  blogs: [
+    {
+      id: 'blog-1',
+      title: 'Delivering Delight with a Lean Courier Stack',
+      imageUrl: placeholderImage,
+      author: 'Alex Johnson',
+      views: 1820,
+      updatedAt: '2024-11-02',
+      link: '/blog/delivering-delight',
+    },
+    {
+      id: 'blog-2',
+      title: 'How to Design a Customer-first Returns Journey',
+      imageUrl: placeholderImage,
+      author: 'Samantha Lee',
+      views: 1345,
+      updatedAt: '2024-10-18',
+      link: '/blog/customer-first-returns',
+    },
+    {
+      id: 'blog-3',
+      title: 'Scaling Logistics with Predictive Analytics',
+      imageUrl: placeholderImage,
+      author: 'David Kim',
+      views: 2015,
+      updatedAt: '2024-09-25',
+      link: '/blog/predictive-analytics',
+    },
+  ],
+};

--- a/react-dashboard/src/pages/Home.tsx
+++ b/react-dashboard/src/pages/Home.tsx
@@ -1,0 +1,35 @@
+import BannerSection from '../components/home/BannerSection';
+import ServicesSection from '../components/home/ServicesSection';
+import WhyCourierSection from '../components/home/WhyCourierSection';
+import PricingSection from '../components/home/PricingSection';
+import AchievementsSection from '../components/home/AchievementsSection';
+import PartnersSection from '../components/home/PartnersSection';
+import BlogsSection from '../components/home/BlogsSection';
+import { mockHomeData } from '../data/mockHomeData';
+import type { HomePageContent } from '../types/home';
+
+interface HomeProps {
+  data?: HomePageContent;
+}
+
+const Home = ({ data = mockHomeData }: HomeProps) => {
+  const pageData = data ?? mockHomeData;
+
+  const handleTrack = (trackingId: string) => {
+    console.log('Track parcel:', trackingId);
+  };
+
+  return (
+    <div className="home-page">
+      <BannerSection content={pageData.banner} onTrack={handleTrack} />
+      <ServicesSection services={pageData.services} />
+      <WhyCourierSection items={pageData.whyCourier} companyName="Baraka Courier" />
+      <PricingSection tiers={pageData.pricing} currency="$" />
+      <AchievementsSection items={pageData.achievements} />
+      <PartnersSection partners={pageData.partners} />
+      <BlogsSection items={pageData.blogs} />
+    </div>
+  );
+};
+
+export default Home;

--- a/react-dashboard/src/types/home.ts
+++ b/react-dashboard/src/types/home.ts
@@ -1,0 +1,74 @@
+export interface BannerContent {
+  titleSegments: Array<{
+    text: string;
+    highlight?: boolean;
+  }>;
+  subtitle: string;
+  imageUrl?: string;
+  trackingPlaceholder: string;
+  trackingButtonLabel: string;
+}
+
+export interface ServiceItem {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+  link: string;
+}
+
+export interface WhyCourierItem {
+  id: string;
+  title: string;
+  imageUrl: string;
+}
+
+export interface PricingRate {
+  id: string;
+  weight: string;
+  category: string;
+  price: number;
+}
+
+export type PricingTierKey = 'same_day' | 'next_day' | 'sub_city' | 'outside_city';
+
+export interface PricingTier {
+  id: PricingTierKey;
+  label: string;
+  rates: PricingRate[];
+}
+
+export interface AchievementItem {
+  id: string;
+  icon: string;
+  label: string;
+  value: number;
+  suffix?: string;
+}
+
+export interface PartnerItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+  link: string;
+}
+
+export interface BlogItem {
+  id: string;
+  title: string;
+  imageUrl: string;
+  author: string;
+  views: number;
+  updatedAt: string;
+  link: string;
+}
+
+export interface HomePageContent {
+  banner: BannerContent;
+  services: ServiceItem[];
+  whyCourier: WhyCourierItem[];
+  pricing: PricingTier[];
+  achievements: AchievementItem[];
+  partners: PartnerItem[];
+  blogs: BlogItem[];
+}


### PR DESCRIPTION
## Summary
- add a Home page composed of banner, services, pricing, achievement, partner, and blog sections styled to match the Blade templates
- introduce reusable home section components, shared monochrome styles, and supporting TypeScript models with placeholder data
- adjust routing to expose the new public Home experience while keeping existing dashboard routes intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd36ab2db48324bc411007668da517