### PR TITLE
Allow configuring CSP connect-src sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+CSP_CONNECT_SRC=
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ This project includes a modern React-based admin dashboard integrated with Larav
    SANCTUM_GUARD=web
    ```
 
-5. **Access Dashboard**
+5. **Content Security Policy (CSP)**
+   If your frontend needs to call APIs hosted on a different origin (for example `http://localhost:8000` during local development), whitelist them with the `CSP_CONNECT_SRC` variable in `.env`:
+   ```env
+   CSP_CONNECT_SRC="http://localhost:8000"
+   ```
+   Multiple values can be provided by separating them with spaces.
+
+6. **Access Dashboard**
    - Login at: `https://baraka.sanaa.ug/login`
    - Dashboard at: `https://baraka.sanaa.ug/admin`
    - Admin credentials: `info@baraka.co` / `admin`


### PR DESCRIPTION
## Summary
- update the security headers middleware to accept additional connect-src hosts from the CSP_CONNECT_SRC environment variable
- document the new CSP configuration option in the README and expose it in .env.example for easy discovery

## Testing
- ⚠️ `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd81ca46a08324a346873e4ac19dee