### PR TITLE
Implement workflow board and operations control screens

### DIFF
--- a/react-dashboard/src/App.tsx
+++ b/react-dashboard/src/App.tsx
@@ -17,6 +17,8 @@ import BranchDetail from './pages/BranchDetail'
 import Merchants from './pages/Merchants'
 import MerchantDetail from './pages/MerchantDetail'
 import MerchantPayments from './pages/MerchantPayments'
+import Shipments from './pages/Shipments'
+import Todo from './pages/Todo'
 import AllCustomers from './pages/sales/AllCustomers'
 import CreateCustomer from './pages/sales/CreateCustomer'
 import Quotations from './pages/sales/Quotations'
@@ -269,6 +271,12 @@ function AppContent() {
                   break
                 case 'merchant/payments':
                   element = <MerchantPayments />
+                  break
+                case 'shipments':
+                  element = <Shipments />
+                  break
+                case 'todo':
+                  element = <Todo />
                   break
                 case 'customers':
                   element = <AllCustomers />

--- a/react-dashboard/src/hooks/useWorkflowBoard.ts
+++ b/react-dashboard/src/hooks/useWorkflowBoard.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { workflowApi, operationsApi } from '../services/api';
+import type { WorkflowBoardResponse } from '../types/workflow';
+
+const STALE_TIME = 30 * 1000;
+
+export const useWorkflowBoard = () =>
+  useQuery<WorkflowBoardResponse, Error>({
+    queryKey: ['workflow-board'],
+    queryFn: async () => {
+      const response = await workflowApi.getBoard();
+      if (!response.success) {
+        throw new Error('Failed to load workflow board');
+      }
+      return response.data;
+    },
+    staleTime: STALE_TIME,
+    refetchInterval: STALE_TIME,
+  });
+
+export const useOperationsInsights = () =>
+  useQuery<{
+    dispatch: Record<string, unknown>;
+    exceptionMetrics: Record<string, unknown> | null;
+    alerts: Array<Record<string, unknown>> | null;
+    shipmentMetrics: Record<string, unknown> | null;
+    workerUtilization: Record<string, unknown> | null;
+  }, Error>({
+    queryKey: ['operations-insights'],
+    queryFn: async () => {
+      const [dispatch, exceptionMetrics, alerts, shipmentMetrics, workerUtilization] = await Promise.allSettled([
+        operationsApi.getDispatchBoard(),
+        operationsApi.getExceptionMetrics(),
+        operationsApi.getAlerts(),
+        operationsApi.getShipmentMetrics(),
+        operationsApi.getWorkerUtilization(),
+      ]);
+
+      if (dispatch.status !== 'fulfilled' || !dispatch.value.success) {
+        throw new Error('Unable to load dispatch board');
+      }
+
+      return {
+        dispatch: dispatch.value.data,
+        exceptionMetrics:
+          exceptionMetrics.status === 'fulfilled' && exceptionMetrics.value.success
+            ? exceptionMetrics.value.data
+            : null,
+        alerts:
+          alerts.status === 'fulfilled' && alerts.value.success
+            ? alerts.value.data
+            : null,
+        shipmentMetrics:
+          shipmentMetrics.status === 'fulfilled' && shipmentMetrics.value.success
+            ? shipmentMetrics.value.data
+            : null,
+        workerUtilization:
+          workerUtilization.status === 'fulfilled' && workerUtilization.value.success
+            ? workerUtilization.value.data
+            : null,
+      };
+    },
+    staleTime: 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });

--- a/react-dashboard/src/pages/Shipments.tsx
+++ b/react-dashboard/src/pages/Shipments.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import Card from '../components/ui/Card';
+import Badge from '../components/ui/Badge';
+import Button from '../components/ui/Button';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+import { useWorkflowBoard, useOperationsInsights } from '../hooks/useWorkflowBoard';
+import type { WorkflowBoardDriverQueue, WorkflowBoardException } from '../types/workflow';
+
+const formatPercent = (value?: number | null) => {
+  if (value === undefined || value === null || Number.isNaN(Number(value))) {
+    return '0%';
+  }
+  return `${Math.round(Number(value))}%`;
+};
+
+const Shipments: React.FC = () => {
+  const {
+    data: workflow,
+    isLoading: isWorkflowLoading,
+    isError: isWorkflowError,
+    error: workflowError,
+    refetch: refetchWorkflow,
+    isFetching: isWorkflowFetching,
+  } = useWorkflowBoard();
+  const {
+    data: operations,
+    isError: isOperationsError,
+    error: operationsError,
+    refetch: refetchOperations,
+    isFetching: isOperationsFetching,
+  } = useOperationsInsights();
+
+  if (isWorkflowLoading && !workflow) {
+    return <LoadingSpinner message="Loading operations control centre" />;
+  }
+
+  if (isWorkflowError || !workflow) {
+    const message = workflowError instanceof Error ? workflowError.message : 'Unable to load operations data';
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center">
+        <Card className="max-w-md text-center">
+          <div className="space-y-4">
+            <div className="inline-flex h-16 w-16 items-center justify-center rounded-full bg-mono-black text-mono-white">
+              <i className="fas fa-exclamation-circle text-2xl" aria-hidden="true" />
+            </div>
+            <div>
+              <h2 className="text-2xl font-semibold text-mono-black">Operations feed unavailable</h2>
+              <p className="text-sm text-mono-gray-600">{message}</p>
+            </div>
+            <Button variant="primary" size="md" onClick={() => refetchWorkflow()}>
+              <i className="fas fa-redo mr-2" aria-hidden="true" />
+              Retry
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const shipmentsKpis = (workflow.kpis?.shipments ?? {}) as Record<string, number>;
+  const performanceKpis = (workflow.kpis?.performance ?? {}) as Record<string, number>;
+  const workerStats = (workflow.kpis?.workers ?? {}) as Record<string, number>;
+  const exceptionSummary = (workflow.exception_metrics?.summary ?? {}) as Record<string, number>;
+  const loadBalancing = (workflow.queues.load_balancing ?? {}) as Record<string, unknown>;
+  const isLoadBalancingActive = Object.keys(loadBalancing ?? {}).length > 0;
+  const driverQueues = (workflow.queues.driver_queues ?? []) as WorkflowBoardDriverQueue[];
+  const exceptions = (workflow.queues.exceptions ?? []) as WorkflowBoardException[];
+  const dispatchSnapshot = (workflow.dispatch_snapshot ?? {}) as Record<string, any>;
+
+  const operationsAlerts = Array.isArray(operations?.alerts)
+    ? (operations?.alerts as Array<Record<string, unknown>>)
+    : ((workflow.kpis?.alerts ?? []) as Array<Record<string, unknown>>);
+
+  const shipmentMetrics = (operations?.shipmentMetrics ?? workflow.shipment_metrics ?? {}) as Record<string, any>;
+
+  const exceptionRate = (shipmentMetrics.exceptions?.exception_rate as number | undefined) ?? 0;
+
+  const refreshAll = () => {
+    refetchWorkflow();
+    refetchOperations();
+  };
+
+  return (
+    <div className="space-y-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Operations Command</p>
+          <h1 className="text-3xl font-semibold text-mono-black sm:text-4xl">Unified Shipment Control Centre</h1>
+          <p className="text-sm text-mono-gray-600">
+            Monitor dispatch queues, worker capacity, and SLA performance with Steve Jobs-level monochrome precision.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          {(isWorkflowFetching || isOperationsFetching) && (
+            <span className="text-xs uppercase tracking-[0.3em] text-mono-gray-500" aria-live="polite">
+              Refreshing…
+            </span>
+          )}
+          <Button variant="secondary" size="sm" className="uppercase tracking-[0.25em]" onClick={refreshAll}>
+            <i className="fas fa-sync-alt mr-2" aria-hidden="true" />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-4">
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Active Shipments</p>
+            <p className="text-3xl font-semibold text-mono-black">{shipmentsKpis.active ?? 0}</p>
+            <p className="text-sm text-mono-gray-600">Out of {shipmentsKpis.total ?? 0} network-wide</p>
+          </div>
+        </Card>
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">On-time Delivery</p>
+            <p className="text-3xl font-semibold text-mono-black">{formatPercent(performanceKpis.on_time_delivery_rate)}</p>
+            <p className="text-sm text-mono-gray-600">Real-time SLA adherence</p>
+          </div>
+        </Card>
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Exception Queue</p>
+            <p className="text-3xl font-semibold text-mono-black">{exceptionSummary.total_exceptions ?? 0}</p>
+            <p className="text-sm text-mono-gray-600">{exceptionSummary.unresolved_exceptions ?? 0} unresolved cases</p>
+          </div>
+        </Card>
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Workforce Utilisation</p>
+            <p className="text-3xl font-semibold text-mono-black">{formatPercent(workerStats.utilization_rate)}</p>
+            <p className="text-sm text-mono-gray-600">{workerStats.active ?? 0} active of {workerStats.total ?? 0}</p>
+          </div>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card className="border border-mono-gray-200">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Dispatch Board</p>
+              <h2 className="text-xl font-semibold text-mono-black">Driver load balancing</h2>
+            </div>
+            <Badge variant="outline" size="sm">{driverQueues.length} active drivers</Badge>
+          </header>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-mono-gray-200 text-left">
+              <thead className="bg-mono-gray-50 text-xs uppercase tracking-[0.3em] text-mono-gray-500">
+                <tr>
+                  <th scope="col" className="px-4 py-3">Driver</th>
+                  <th scope="col" className="px-4 py-3">Assignments</th>
+                  <th scope="col" className="px-4 py-3">Capacity</th>
+                  <th scope="col" className="px-4 py-3">Utilisation</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-mono-gray-100 text-sm text-mono-gray-700">
+                {driverQueues.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-6 text-center text-sm text-mono-gray-500">
+                      No driver assignments available.
+                    </td>
+                  </tr>
+                ) : (
+                  driverQueues.map((queue) => (
+                    <tr key={`${queue.worker_id}-${queue.worker_name}`}>
+                      <td className="px-4 py-3 font-medium text-mono-black">{queue.worker_name ?? 'Unassigned'}</td>
+                      <td className="px-4 py-3">{queue.assigned_shipments}</td>
+                      <td className="px-4 py-3">{queue.capacity ?? '—'}</td>
+                      <td className="px-4 py-3">{formatPercent(queue.utilization)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card className="border border-mono-gray-200">
+          <header className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Network Pulse</p>
+            <h2 className="text-lg font-semibold text-mono-black">Load status</h2>
+          </header>
+          <div className="mt-4 space-y-3 text-sm text-mono-gray-600">
+            <div className="rounded-2xl border border-mono-gray-200 p-4">
+              <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">Queue depth</p>
+              <p className="text-mono-black">{(dispatchSnapshot.queue_depth as number | undefined) ?? '—'} shipments</p>
+            </div>
+            <div className="rounded-2xl border border-mono-gray-200 p-4">
+              <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">Load balancing</p>
+              <p className="text-mono-black">{isLoadBalancingActive ? 'Active balancing in progress' : 'Optimisation pending'}</p>
+            </div>
+            <div className="rounded-2xl border border-mono-gray-200 p-4">
+              <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">Exception rate</p>
+              <p className="text-mono-black">{formatPercent(exceptionRate)}</p>
+            </div>
+          </div>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card className="border border-mono-gray-200">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Exception Tower</p>
+              <h2 className="text-xl font-semibold text-mono-black">Active exceptions</h2>
+            </div>
+            <Badge variant="outline" size="sm">{exceptions.length} open</Badge>
+          </header>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-mono-gray-200 text-left">
+              <thead className="bg-mono-gray-50 text-xs uppercase tracking-[0.3em] text-mono-gray-500">
+                <tr>
+                  <th scope="col" className="px-4 py-3">Shipment</th>
+                  <th scope="col" className="px-4 py-3">Type</th>
+                  <th scope="col" className="px-4 py-3">Severity</th>
+                  <th scope="col" className="px-4 py-3">Branch</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-mono-gray-100 text-sm text-mono-gray-700">
+                {exceptions.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-6 text-center text-sm text-mono-gray-500">
+                      All shipments are healthy.
+                    </td>
+                  </tr>
+                ) : (
+                  exceptions.map((exception) => (
+                    <tr key={exception.id ?? exception.tracking_number}>
+                      <td className="px-4 py-3 font-medium text-mono-black">{exception.tracking_number ?? '—'}</td>
+                      <td className="px-4 py-3">{exception.exception_type ?? '—'}</td>
+                      <td className="px-4 py-3">{exception.exception_severity ?? '—'}</td>
+                      <td className="px-4 py-3">{exception.branch ?? '—'}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card className="border border-mono-gray-200">
+          <header className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Critical Alerts</p>
+            <h2 className="text-lg font-semibold text-mono-black">Immediate actions</h2>
+          </header>
+          <div className="mt-4 space-y-3 text-sm text-mono-gray-600">
+            {operationsAlerts?.length ? (
+              operationsAlerts.map((alert, index) => (
+                <div key={`${alert.type ?? index}`} className="rounded-2xl border border-mono-gray-200 p-4">
+                  <p className="text-sm font-semibold text-mono-black">{(alert.title as string) ?? 'Operational Alert'}</p>
+                  <p>{(alert.message as string) ?? 'Review in control tower'}</p>
+                  <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">{(alert.severity as string)?.toUpperCase() ?? 'INFO'}</p>
+                </div>
+              ))
+            ) : (
+              <p>No critical alerts. Keep the cadence.</p>
+            )}
+            {isOperationsError && (
+              <div className="rounded-2xl border border-dashed border-mono-gray-300 p-4 text-xs text-mono-gray-500">
+                {(operationsError as Error)?.message ?? 'Operations insight service unavailable.'}
+              </div>
+            )}
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+};
+
+export default Shipments;

--- a/react-dashboard/src/pages/Todo.tsx
+++ b/react-dashboard/src/pages/Todo.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import Badge from '../components/ui/Badge';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+import { useWorkflowBoard } from '../hooks/useWorkflowBoard';
+import type { WorkflowBoardShipment, WorkflowBoardException, WorkflowBoardNotification } from '../types/workflow';
+
+const formatDateTime = (value?: string | null) => {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+};
+
+const priorityTone: Record<string, string> = {
+  high: 'bg-mono-black text-mono-white',
+  medium: 'bg-mono-gray-800 text-mono-white',
+  low: 'bg-mono-gray-500 text-mono-white',
+};
+
+const Todo: React.FC = () => {
+  const { data, isLoading, isError, error, refetch, isFetching } = useWorkflowBoard();
+
+  if (isLoading && !data) {
+    return <LoadingSpinner message="Loading workflow actions" />;
+  }
+
+  if (isError || !data) {
+    const message = error instanceof Error ? error.message : 'Unable to load workflow actions';
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center">
+        <Card className="max-w-md text-center">
+          <div className="space-y-4">
+            <div className="inline-flex h-16 w-16 items-center justify-center rounded-full bg-mono-black text-mono-white">
+              <i className="fas fa-exclamation-triangle text-2xl" aria-hidden="true" />
+            </div>
+            <div>
+              <h2 className="text-2xl font-semibold text-mono-black">Workflow board unavailable</h2>
+              <p className="text-sm text-mono-gray-600">{message}</p>
+            </div>
+            <Button variant="primary" size="md" onClick={() => refetch()}>
+              <i className="fas fa-redo mr-2" aria-hidden="true" />
+              Retry
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const shipments = data.queues.unassigned_shipments as WorkflowBoardShipment[];
+  const exceptions = data.queues.exceptions as WorkflowBoardException[];
+  const notifications = data.notifications as WorkflowBoardNotification[];
+
+  return (
+    <div className="space-y-10">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Control Tower</p>
+          <h1 className="text-3xl font-semibold text-mono-black sm:text-4xl">Workflow Board</h1>
+          <p className="text-sm text-mono-gray-600">
+            Coordinate dispatch, resolve exceptions, and keep the network flowing with a single monochrome cockpit.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          {isFetching && (
+            <span className="text-xs uppercase tracking-[0.3em] text-mono-gray-500" aria-live="polite">
+              Refreshing…
+            </span>
+          )}
+          <Button variant="secondary" size="sm" className="uppercase tracking-[0.25em]" onClick={() => refetch()}>
+            <i className="fas fa-sync-alt mr-2" aria-hidden="true" />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Unassigned Shipments</p>
+            <h2 className="text-3xl font-semibold text-mono-black">{shipments.length}</h2>
+            <p className="text-sm text-mono-gray-600">Awaiting dispatch allocation</p>
+          </div>
+        </Card>
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Active Exceptions</p>
+            <h2 className="text-3xl font-semibold text-mono-black">{exceptions.length}</h2>
+            <p className="text-sm text-mono-gray-600">Flagged for immediate investigation</p>
+          </div>
+        </Card>
+        <Card className="border border-mono-gray-200 shadow-inner">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Unread Signals</p>
+            <h2 className="text-3xl font-semibold text-mono-black">{notifications.length}</h2>
+            <p className="text-sm text-mono-gray-600">Operational alerts for the next shift</p>
+          </div>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card className="border border-mono-gray-200">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Dispatch Actions</p>
+              <h2 className="text-xl font-semibold text-mono-black">Unassigned queue</h2>
+            </div>
+            <Badge variant="outline" size="sm">{shipments.length} pending</Badge>
+          </header>
+          <div className="mt-4 divide-y divide-mono-gray-200">
+            {shipments.length === 0 ? (
+              <p className="py-6 text-sm text-mono-gray-600">Network is fully assigned. Great work.</p>
+            ) : (
+              shipments.map((shipment) => (
+                <div key={shipment.id ?? shipment.tracking_number} className="flex flex-col gap-2 py-4 lg:flex-row lg:items-center lg:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-mono-black">{shipment.tracking_number ?? 'Unknown shipment'}</p>
+                    <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">
+                      {shipment.origin_branch ?? 'Origin pending'} → {shipment.destination_branch ?? 'Destination pending'}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-mono-gray-600">
+                    <span>
+                      <i className="fas fa-clock mr-2" aria-hidden="true" />
+                      {formatDateTime(shipment.promised_at)}
+                    </span>
+                    <Badge
+                      variant="solid"
+                      size="sm"
+                      className={priorityTone[shipment.priority ?? 'low'] ?? 'bg-mono-gray-700 text-mono-white'}
+                    >
+                      {shipment.priority ?? 'Priority TBD'}
+                    </Badge>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </Card>
+
+        <Card className="border border-mono-gray-200">
+          <header className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Signals</p>
+            <h2 className="text-lg font-semibold text-mono-black">Latest Notifications</h2>
+          </header>
+          <ul className="mt-4 space-y-3 text-sm text-mono-gray-600">
+            {notifications.length === 0 ? (
+              <li>No unread notifications.</li>
+            ) : (
+              notifications.map((notification) => (
+                <li key={notification.id} className="rounded-2xl border border-mono-gray-200 p-4">
+                  <p className="font-medium text-mono-black">{notification.title ?? 'Operational Alert'}</p>
+                  <p>{notification.message ?? 'See control tower for more details.'}</p>
+                  <p className="text-xs uppercase tracking-[0.25em] text-mono-gray-500">{formatDateTime(notification.created_at)}</p>
+                </li>
+              ))
+            )}
+          </ul>
+        </Card>
+      </section>
+
+      <section>
+        <Card className="border border-mono-gray-200">
+          <header className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-mono-gray-500">Exception Review</p>
+              <h2 className="text-xl font-semibold text-mono-black">Priority cases</h2>
+            </div>
+            <Badge variant="outline" size="sm">{exceptions.length} open</Badge>
+          </header>
+          <div className="mt-4 overflow-x-auto">
+            <table className="min-w-full divide-y divide-mono-gray-200 text-left">
+              <thead className="bg-mono-gray-50 text-xs uppercase tracking-[0.3em] text-mono-gray-500">
+                <tr>
+                  <th scope="col" className="px-4 py-3">Shipment</th>
+                  <th scope="col" className="px-4 py-3">Type</th>
+                  <th scope="col" className="px-4 py-3">Severity</th>
+                  <th scope="col" className="px-4 py-3">Branch</th>
+                  <th scope="col" className="px-4 py-3">Updated</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-mono-gray-100 text-sm text-mono-gray-700">
+                {exceptions.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-6 text-center text-sm text-mono-gray-500">
+                      All exceptions resolved.
+                    </td>
+                  </tr>
+                ) : (
+                  exceptions.map((exception) => (
+                    <tr key={exception.id ?? exception.tracking_number}>
+                      <td className="px-4 py-3 font-medium text-mono-black">{exception.tracking_number ?? '—'}</td>
+                      <td className="px-4 py-3">{exception.exception_type ?? '—'}</td>
+                      <td className="px-4 py-3">
+                        <Badge variant="solid" size="sm" className={priorityTone[exception.exception_severity ?? 'low'] ?? 'bg-mono-gray-700 text-mono-white'}>
+                          {exception.exception_severity ?? 'Unrated'}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3">{exception.branch ?? '—'}</td>
+                      <td className="px-4 py-3">{formatDateTime(exception.updated_at)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+};
+
+export default Todo;

--- a/react-dashboard/src/services/api.ts
+++ b/react-dashboard/src/services/api.ts
@@ -35,6 +35,7 @@ import type {
   MerchantListParams,
   MerchantListResponse,
 } from '../types/merchants';
+import type { WorkflowBoardResponse } from '../types/workflow';
 
 export interface ApiResponse<T> {
   success: boolean;
@@ -295,6 +296,36 @@ export const merchantsApi = {
   },
   getMerchant: async (merchantId: number | string): Promise<ApiResponse<MerchantDetailResponse>> => {
     const response = await api.get<ApiResponse<MerchantDetailResponse>>(`/v10/merchants/${merchantId}`);
+    return response.data;
+  },
+};
+
+export const workflowApi = {
+  getBoard: async (): Promise<ApiResponse<WorkflowBoardResponse>> => {
+    const response = await api.get<ApiResponse<WorkflowBoardResponse>>('/v10/workflow-board');
+    return response.data;
+  },
+};
+
+export const operationsApi = {
+  getDispatchBoard: async (): Promise<ApiResponse<Record<string, unknown>>> => {
+    const response = await api.get<ApiResponse<Record<string, unknown>>>('/v10/operations/dispatch-board');
+    return response.data;
+  },
+  getExceptionMetrics: async (): Promise<ApiResponse<Record<string, unknown>>> => {
+    const response = await api.get<ApiResponse<Record<string, unknown>>>('/v10/operations/exception-metrics');
+    return response.data;
+  },
+  getAlerts: async (): Promise<ApiResponse<Record<string, unknown>[]>> => {
+    const response = await api.get<ApiResponse<Record<string, unknown>[]>>('/v10/operations/alerts');
+    return response.data;
+  },
+  getShipmentMetrics: async (): Promise<ApiResponse<Record<string, unknown>>> => {
+    const response = await api.get<ApiResponse<Record<string, unknown>>>('/v10/operations/shipment-metrics');
+    return response.data;
+  },
+  getWorkerUtilization: async (): Promise<ApiResponse<Record<string, unknown>>> => {
+    const response = await api.get<ApiResponse<Record<string, unknown>>>('/v10/operations/worker-utilization');
     return response.data;
   },
 };

--- a/react-dashboard/src/types/workflow.ts
+++ b/react-dashboard/src/types/workflow.ts
@@ -1,0 +1,60 @@
+export interface WorkflowBoardQueues {
+  unassigned_shipments: Array<WorkflowBoardShipment>;
+  exceptions: Array<WorkflowBoardException>;
+  load_balancing: Record<string, unknown>;
+  driver_queues: Array<WorkflowBoardDriverQueue>;
+}
+
+export interface WorkflowBoardShipment {
+  id?: number | string;
+  tracking_number?: string | null;
+  service_level?: string | null;
+  status?: string | null;
+  origin_branch?: string | null;
+  destination_branch?: string | null;
+  promised_at?: string | null;
+  created_at?: string | null;
+  priority?: string | null;
+}
+
+export interface WorkflowBoardException {
+  id?: number | string;
+  tracking_number?: string | null;
+  exception_type?: string | null;
+  exception_severity?: string | null;
+  age_hours?: number | null;
+  branch?: string | null;
+  updated_at?: string | null;
+}
+
+export interface WorkflowBoardDriverQueue {
+  worker_id: number | string | null;
+  worker_name: string | null;
+  assigned_shipments: number;
+  capacity: number | null;
+  utilization: number | null;
+}
+
+export interface WorkflowBoardNotification {
+  id: number | string;
+  title?: string;
+  message?: string;
+  created_at?: string;
+  type?: string;
+}
+
+export interface WorkflowBoardResponse {
+  hub_branch: {
+    id: number;
+    name: string;
+    code: string | null;
+    type: string | null;
+  } | null;
+  queues: WorkflowBoardQueues;
+  dispatch_snapshot: Record<string, unknown> | null;
+  kpis: Record<string, unknown>;
+  shipment_metrics: Record<string, unknown>;
+  worker_utilization: Record<string, unknown>;
+  exception_metrics: Record<string, unknown>;
+  notifications: WorkflowBoardNotification[];
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -101,6 +101,8 @@ Route::prefix('v10')->group(function () {
             Route::get('{merchant}', [MerchantManagementController::class, 'show']);
         });
 
+        Route::get('workflow-board', [WorkflowBoardController::class, 'index']);
+
         Route::post('/register', [AuthController::class, 'register']);
         // Customer self-service auth (separate namespace)
         Route::prefix('auth')->group(function () {


### PR DESCRIPTION
## Summary
- extend the workflow board API to expose dispatch snapshots, driver queues, and exception metrics for the SPA
- add workflow/operations client hooks and types plus wire navigation to the new dashboard routes
- build monochrome to-do and shipments control centre pages backed by live Sanctum data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e061802f9883249e4a27872c60af8f