### PR TITLE
Fix SPA login CSRF handling

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -29,6 +29,14 @@ class VerifyCsrfToken extends Middleware
         // aamarpay
         '/aamarpay-success',
         '/aamarpay-fail',
+
+        // SPA auth endpoints hit by browser extensions / SPAs that cannot share
+        // first-party cookies when executing on a different origin. Bypass CSRF
+        // verification for these API routes because Sanctum issues tokens that
+        // will be used for all subsequent requests.
+        '/api/auth/login',
+        '/api/auth/register',
+        '/api/auth/logout',
     ];
     public function handle($request, Closure $next)
     {


### PR DESCRIPTION
## Summary
- allow the API auth endpoints that power the SPA/extension login flow to bypass CSRF validation so their requests no longer return 419 responses when the browser cannot share first-party cookies
- document why the exemption exists to make the security trade-off explicit

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c32605a148324a9d150148a21496a)